### PR TITLE
Fixed ynbool for python3 support

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -231,8 +231,9 @@ class ynbool:
     def __init__(self, val=False):
         self.val = bool(val and val not in (b'no', 'no'))
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self.val
+    __nonzero__=__bool__
 
     def __str__(self):
         return 'yes' if self.val else 'no'


### PR DESCRIPTION
Old version didn't seem to work with the not keyword:
(not ynbool(False) == False) == True