### PR TITLE
Fix unobserve_property

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -54,6 +54,7 @@ class ErrorCode:
     @classmethod
     def raise_for_ec(kls, func, *args):
         ec = func(*args)
+        ec = 0 if ec > 0 else ec
         ex = kls.EXCEPTION_DICT.get(ec , kls.DEFAULT_ERROR_HANDLER)
         if ex:
             raise ex(ec, *args)
@@ -420,8 +421,11 @@ class MPV:
         _mpv_observe_property(self.handle, hash(handler), name.encode(), MpvFormat.STRING)
 
     def unobserve_property(self, handler):
-        _mpv_observe_property(self.handle, hash(handler))
-        del self._property_handlers[hash(handler)]
+        _mpv_unobserve_property(self.handle, hash(handler))
+        try:
+            del self._property_handlers[hash(handler)]
+        except KeyError:
+            pass
     
     @property
     def metadata(self):


### PR DESCRIPTION
There were three problems:

1. MPV.unobserve_property called _mpv_observe_property instead of _mpv_unobserve_property.
2. _mpv_unobserve_property returns the number of properties that were assigned to the handler that is being removed. Because the return value is not 0 in such a case, ErrorCode.raise_for_ec tries to raise an error. To fix that, I changed the ErrorCode.raise_for_ec functon not to raise an error if ec is larger than 0. (If there is a positive return value, there should not have been an error anyway, if I'm not mistaken.)
3. Calling MPV.unobserve_property for a handle that is not currently been used should not result in a KeyError being raised.

An alternative to 2. would be to add a restype to the _handle_func of 'mpv_unobserve_property' and returning that value in MPV.unobserve_property. (That way, raise_for_ec is never called.)  But I don't think this value is useful in any way. Even the built in lua interface does not return that value.