### PR TITLE
Fix percent-pos property, Fix property getter for non-available properties, Improve Windows support

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -525,7 +525,7 @@ ALL_PROPERTIES = {
         'avsync':                      (float,  'r'),
         'total-avsync-change':         (float,  'r'),
         'drop-frame-count':            (int,    'r'),
-        'percent-pos':                 (int,    'rw'),
+        'percent-pos':                 (float,  'rw'),
         'ratio-pos':                   (float,  'rw'),
         'time-pos':                    (float,  'rw'),
         'time-start':                  (float,  'r'),

--- a/mpv.py
+++ b/mpv.py
@@ -620,7 +620,8 @@ ALL_PROPERTIES = {
 
 def bindproperty(MPV, name, proptype, access):
     def getter(self):
-        return proptype(_ensure_encoding(_mpv_get_property_string(self.handle, name.encode())))
+        value = _ensure_encoding(_mpv_get_property_string(self.handle, name.encode()))
+        return proptype(value) if value is not None else value
     def setter(self, value):
         _mpv_set_property_string(self.handle, name.encode(), str(proptype(value)).encode())
     def barf(*args):

--- a/mpv.py
+++ b/mpv.py
@@ -8,7 +8,10 @@ from warnings import warn
 # vim: ts=4 sw=4
 
 
-backend = CDLL('libmpv.so')
+if os.name == 'nt':
+    backend = CDLL('mpv-1.dll')
+else:
+    backend = CDLL('libmpv.so')
 
 
 class MpvHandle(c_void_p):


### PR DESCRIPTION
1. The ``percent-pos`` property has to be ``float``. Trying to retrieve this property was raising an exception, because e.g. ``int("0.0000")`` raises a ValueError.

2. Properties which are not currently available weren't handled properly: The getter for a property that is not available with proptype ``str`` would return ``None`` (as a string) instead of ``None``. Trying to retrieve a non-available property with proptype ``int`` would raise a TypeError, because the getter tries to call ``int(None)``. An alternative would be to raise some kind of exception for non-available properties, but I would prefer the getter to return ``None``. For example ``None`` should be a valid value for the property ``path`` if no video is loaded yet.

3. Windows users don't have to edit the source code anymore.