### PR TITLE
Implement '==' and '!=' for ynbool, Fix DEFAULT_ERROR_HANDLER

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -50,9 +50,9 @@ class ErrorCode:
             -12:    lambda *a: SystemError('Error running mpv command', *a)
         }
 
-    @classmethod
+    @staticmethod
     def DEFAULT_ERROR_HANDLER(ec, *args):
-        return ValueError(_mpv_error_string(ec).decode(), ec, *a)
+        return ValueError(_mpv_error_string(ec).decode(), ec, *args)
 
     @classmethod
     def raise_for_ec(kls, func, *args):

--- a/mpv.py
+++ b/mpv.py
@@ -259,6 +259,9 @@ class ynbool:
     def __repr__(self):
         return str(self.val)
 
+    def __eq__(self, other):
+        return str(self) == other or bool(self) == other
+
 def _ensure_encoding(possibly_bytes):
     return possibly_bytes.decode() if type(possibly_bytes) is bytes else possibly_bytes
 


### PR DESCRIPTION
Hey, I stumbled upon two minor problems:

1. ``ynbool(True) == "yes"``, ``ynbool(True) == True`` and ``ynbool(True) == ynbool(True)`` were not working. (They all should be ``True``.) That was not a big problem, mostly you would do something like ``if <property>: do_something()``, which works fine, because ``if`` only relies upon ``__bool__``. (``!=`` works now too, by default Python also uses ``__eq__`` for that and negates the result.)
2. ``DEFAULT_ERROR_HANDLER`` wasn't working, because it had the classmethod decorator, even though it wasn't a classmethod.