### PR TITLE
Fix missing required positional argument error

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -378,7 +378,7 @@ def _event_loop(event_handle, playback_cond, event_callbacks, message_handlers, 
                     args = (pc['data'], pc['format'])
 
                 for handler in property_handlers[name]:
-                    handler(*args)
+                    handler(None, *args)
             if eid == MpvEventID.LOG_MESSAGE and log_handler is not None:
                 ev = devent['event']
                 log_handler(ev['level'], ev['prefix'], ev['text'])


### PR DESCRIPTION
Fix for the following error:

```
TypeError: <lambda>() missing 1 required positional argument: 'pos'
Traceback (most recent call last):
  File "/my/test/dir/python-mpv/mpv.py", line 381, in _event_loop
    handler(*args)
```