### PR TITLE
Fix `unobserve_property` RuntimeError

### DIFF
--- a/mpv-test.py
+++ b/mpv-test.py
@@ -206,5 +206,32 @@ class TestLifecycle(unittest.TestCase):
         handler.assert_any_call('info', 'cplayer', 'Playing: ./test.webm')
 
 
+class RegressionTests(unittest.TestCase):
+
+    def test_unobserve_property_runtime_error(self):
+        """
+        Ensure a `RuntimeError` is not thrown within
+        `unobserve_property`.
+        """
+        handler = mock.Mock()
+        handler.observed_mpv_properties = []
+
+        m = mpv.MPV()
+        m.observe_property('loop', handler)
+
+        try:
+            m.unobserve_property('loop', handler)
+        except RuntimeError:
+            self.fail(
+                """
+                "RuntimeError" exception thrown within
+                `unobserve_property`
+                """,
+            )
+        finally:
+            m.terminate()
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/mpv.py
+++ b/mpv.py
@@ -681,8 +681,15 @@ class MPV(object):
         fmts = self._property_handlers[name]
         for fmt, handlers in fmts.items():
             handlers.remove(handler)
-            if not handlers:
-                del fmts[fmt]
+
+        # remove all properties that have no handlers
+        empty_props = [
+            fmt for fmt, handler in fmts.items() if not handler
+        ]
+
+        for fmt in empty_props:
+            del fmts[fmt]
+
         if not fmts:
             _mpv_unobserve_property(self._event_handle, hash(name)&0xffffffffffffffff)
 


### PR DESCRIPTION
When I tried to unobserve a property, I received a `RuntimeError`. This fixes it.