### PR TITLE
Add 3rd-party dependency to `setup.py` and move `import` statement to the top of the module

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -28,7 +28,7 @@ import collections
 import re
 import traceback
 
-# vim: ts=4 sw=4 et
+from PIL import Image
 
 if os.name == 'nt':
     backend = CDLL('mpv-1.dll')
@@ -661,7 +661,6 @@ class MPV(object):
 
     def screenshot_raw(self, includes='subtitles'):
         """ Mapped mpv screenshot_raw command, see man mpv(1). Returns a pillow Image object."""
-        from PIL import Image
         res = self.node_command('screenshot-raw', includes)
         if res['format'] != 'bgr0':
             raise ValueError('Screenshot in unknown format "{}". Currently, only bgr0 is supported.'
@@ -1055,3 +1054,4 @@ class MPV(object):
         except AttributeError:
             return None
 
+# vim: ts=4 sw=4 et

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ setup(
     author = 'jaseg',
     author_email = 'github@jaseg.net',
     license = 'AGPLv3+',
-    keywords = ['mpv', 'library', 'video', 'audio', 'player', 'display',
-        'multimedia'],
+    keywords = ['mpv', 'library', 'video', 'audio', 'player', 'display', 'multimedia'],
     classifiers = [
         'Development Status :: 4 - Beta',
         'Environment :: Win32 (MS Windows)',
@@ -25,5 +24,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.5',
         'Topic :: Multimedia :: Sound/Audio :: Players',
-        'Topic :: Multimedia :: Video :: Display']
-)
+        'Topic :: Multimedia :: Video :: Display'],
+    install_requires=['PIL'])


### PR DESCRIPTION
About the vim modeline, by default Vim will read the 5 first and last lines, and I think it's not *that* important to move it on top of the header.