### PR TITLE
Fixed TypeError: _handle_key_binding_message() signature with mpv < v0.15.0

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -993,7 +993,7 @@ class MPV(object):
             raise TypeError('register_key_binding expects either an str with an mpv command or a python callable.')
         self.command('enable-section', binding_name, 'allow-hide-cursor+allow-vo-dragging')
 
-    def _handle_key_binding_message(self, binding_name, key_state, key_name):
+    def _handle_key_binding_message(self, binding_name, key_state, key_name=None):
         self._key_binding_handlers[binding_name](key_state, key_name)
 
     def unregister_key_binding(self, keydef):


### PR DESCRIPTION
`key-binding` message has key name parameter only since mpv version 0.15.0 (as stated in manual), therefore trying to bind keys with earlier versions results in `TypeError: _handle_key_binding_message() missing 1 required positional argument: 'key_name'.`

This change makes this argument optional and default to `None`.