### PR TITLE
Add workaround for MPV.show_text

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -757,6 +757,7 @@ class MPV(object):
 
     def show_text(self, string, duration='-', level=None):
         """Mapped mpv show_text command, see man mpv(1)."""
+        if duration in ('-', b'-'): duration = self['osd-duration']
         self.command('show_text', string, duration, level)
 
     def show_progress(self):


### PR DESCRIPTION
Currently `MPV.command` cannot pass `-` for `show_text`'s default duration (#69). Until the real fix arrives, I hope this helps.