### PR TITLE
fix: getProcAddr function should return a function or 0

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -308,7 +308,7 @@ class MpvEventClientMessage(Structure):
 WakeupCallback = CFUNCTYPE(None, c_void_p)
 
 OpenGlCbUpdateFn = CFUNCTYPE(None, c_void_p)
-OpenGlCbGetProcAddrFn = CFUNCTYPE(None, c_void_p, c_char_p)
+OpenGlCbGetProcAddrFn = CFUNCTYPE(c_void_p, c_void_p, c_char_p)
 
 def _handle_func(name, args, restype, errcheck, ctx=MpvHandle):
     func = getattr(backend, name)


### PR DESCRIPTION
From the example in official repo:https://github.com/mpv-player/mpv-examples/blob/master/libmpv/qt_opengl/mpvwidget.cpp#L11, we can see that the `get_proc_addr` return a `void *` function. We also should have `c_void_p` as return type.

An example to test this functionality: https://gist.github.com/cosven/b313de2acce1b7e15afda263779c0afc