### PR TITLE
Use stride//4 rather than the returned image w

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -683,7 +683,7 @@ class MPV(object):
         if res['format'] != 'bgr0':
             raise ValueError('Screenshot in unknown format "{}". Currently, only bgr0 is supported.'
                     .format(res['format']))
-        img = Image.frombytes('RGBA', (res['w'], res['h']), res['data'])
+        img = Image.frombytes('RGBA', (res['stride']//4, res['h']), res['data'])
         b,g,r,a = img.split()
         return Image.merge('RGB', (r,g,b))
 


### PR DESCRIPTION
As per discussion on the mpv issue https://github.com/mpv-player/mpv/issues/7076 to handle the screenshot-raw when vf cropping filters are in use.