### PR TITLE
Allow mpv-1.dll to be placed in python script directory

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -31,7 +31,7 @@ if os.name == 'nt':
 	try:
 		backend = CDLL('mpv-1.dll')
 	except FileNotFoundError:
-		backend = CDLL(os.path.abspath('mpv-1.dll'))
+		backend = CDLL(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'mpv-1.dll'))
     fs_enc = 'utf-8'
 else:
     import locale

--- a/mpv.py
+++ b/mpv.py
@@ -28,7 +28,10 @@ import re
 import traceback
 
 if os.name == 'nt':
-    backend = CDLL('mpv-1.dll')
+	try:
+		backend = CDLL('mpv-1.dll')
+	except FileNotFoundError:
+		backend = CDLL(os.path.abspath('mpv-1.dll'))
     fs_enc = 'utf-8'
 else:
     import locale


### PR DESCRIPTION
The windows dll search strategy is pathetic. For me at least, it only looks in system32 and the executable directory - not the current directory. This works fine for compiled programs, but for python, the executable is likely to be far away from the script which is being executed. And I don't know about you, but I don't want my python scripts installing their dependencies alongside my system-wide python interpreter. This change allows python scripts using mpv.py to simply ship mpv-1.dll along with them, and mpv.py will attempt to load it for the current working directory.