### PR TITLE
Actually search sys.path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,16 +19,21 @@ Installation
 Requirements
 ~~~~~~~~~~~~
 
-libmpv (no kidding!)
-....................
+libmpv
+......
 ``libmpv.so`` either locally (in your current working directory) or somewhere in your system library search path. This
 module is somewhat lenient as far as ``libmpv`` versions are concerned but since ``libmpv`` is changing quite frequently
 you'll only get all the newest features when using an up-to-date version of this module. The unit tests for this module
 do some basic automatic version compatibility checks. If you discover anything missing here, please open an `issue`_ or
 submit a `pull request`_ on github.
 
-Python 2.7, 3.5 or 3.6 (officially)
-...................................
+On Windows you can place libmpv anywhere in your ``%PATH%`` (e.g. next to ``python.exe``) or next to this module's
+``mpv.py``.  Before falling back to looking in the mpv module's directory, python-mpv uses the DLL search order built
+into ctypes, which is different to the one Windows uses internally. Consult `this stackoverflow post
+<https://stackoverflow.com/a/23805306>`__ for details.
+
+Python >= 3.5 (officially)
+..........................
 The ``master`` branch officially only supports recent python releases (3.5 onwards), but there is the somewhat outdated
 but functional `py2compat branch`_ providing Python 2 compatibility.
 

--- a/mpv.py
+++ b/mpv.py
@@ -29,12 +29,13 @@ import traceback
 
 if os.name == 'nt':
     try:
-        backend = CDLL(os.path.abspath(ctypes.util.find_library('mpv-1.dll')))
+        backend = CDLL(ctypes.util.find_library('mpv-1.dll'))
     except TypeError:
         raise OSError("Cannot find mpv-1.dll in your PATH. The best way to deal with this is to "
                       "ship mpv-1.dll with your script and add "
-                      "'os.environ['PATH'] += os.path.dirname(__file__)' before 'import mpv'."
-                      " If mpv-1.dll is located elsewhere, you can add that path to os.environ['PATH'].")
+                      "os.environ['PATH'] = os.path.dirname(__file__) + os.pathsep + os.environ['PATH']"
+                      "before 'import mpv'. If mpv-1.dll is located elsewhere, "
+                      "you can add that path to os.environ['PATH'].")
     fs_enc = 'utf-8'
 else:
     import locale

--- a/mpv.py
+++ b/mpv.py
@@ -29,9 +29,12 @@ import traceback
 
 if os.name == 'nt':
     try:
-        backend = CDLL('mpv-1.dll')
-    except FileNotFoundError:
-        backend = CDLL(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'mpv-1.dll'))
+        backend = CDLL(os.path.abspath(ctypes.util.find_library('mpv-1.dll')))
+    except TypeError:
+        raise OSError("Cannot find mpv-1.dll in your PATH. The best way to deal with this is to "
+                      "ship mpv-1.dll with your script and add "
+                      "'os.environ['PATH'] += os.path.dirname(__file__)' before 'import mpv'."
+                      " If mpv-1.dll is located elsewhere, you can add that path to os.environ['PATH'].")
     fs_enc = 'utf-8'
 else:
     import locale


### PR DESCRIPTION
Here's the root of the issue. `CDLL` doesn't search sys.path. I don't know what it does - the actual logic is native code and I CBA digging into the cpython source to find out. But in practise it only searches system32 and beside python.exe. `find_library` is the tool which we need to use to make this work. I've also added a helpful error message. This change brings the code in line with the advice you added in the README, regarding adding the dll to PATH.

Oh, and I was sure to convert to spaces this time. Should be safe to use.

I'm sorry this took so long to figure out. I'm pretty sure that *this time*, there is a good story for using and deploying mpv.py on windows.

Below this line is old and irrelevant. Adding my path to the beginning of PATH fixes all that.

---

I added abspath to work around a bug I had - when there is a `;;` in PATH, that's interpreted as an empty string. The filename of the library is added on to this, and the result is that `find_library` looks in the current directory.  

This works for me because that's where I have mpv-1.dll stored, so `find_library` returns the string `mpv-1.dll` - literally what you had originally. I understand this will bring back your concerns about security - however I don't think a normal windows install will have a `;;` in PATH, so most people should not encounter this.