### PR TITLE
Add GTK/OpenGL example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,7 @@ PyQT embedding
     sys.exit(app.exec_())
 
 PyGObject embedding
-..............
+...................
 
 .. code:: python
     
@@ -238,7 +238,7 @@ Github user cosven_ has managed to `make mpv render into a Qt widget using OpenG
 <https://gist.github.com/cosven/b313de2acce1b7e15afda263779c0afc>`__ through this python API.
 
 Using OpenGL from PyGObject
-......................
+...........................
 Just like it is possible to render into a Qt widget, it `also is possible to render into a GTK widget
 <https://gist.github.com/trin94/a930f2a13cee1c9fd21cab0393bf4663>`__ through this python API.
 

--- a/README.rst
+++ b/README.rst
@@ -237,6 +237,11 @@ Using OpenGL from PyQT
 Github user cosven_ has managed to `make mpv render into a Qt widget using OpenGL
 <https://gist.github.com/cosven/b313de2acce1b7e15afda263779c0afc>`__ through this python API.
 
+Using OpenGL from PyGObject
+......................
+Just like it is possible to render into a Qt widget, it `also is possible to render into a GTK widget
+<https://gist.github.com/trin94/a930f2a13cee1c9fd21cab0393bf4663>`__ through this python API.
+
 Coding Conventions
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -193,7 +193,7 @@ PyQT embedding
     win.show()
     sys.exit(app.exec_())
 
-PyGtk embedding
+PyGObject embedding
 ..............
 
 .. code:: python


### PR DESCRIPTION
This is the GTK equivalent to @cosven's Qt/OpenGL example.

Direct link to gist: https://gist.github.com/trin94/a930f2a13cee1c9fd21cab0393bf4663

Also see #99 