### PR TITLE
remove superfluous whitespaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -255,7 +255,7 @@ PyGObject embedding
         application = MainClass()
         Gtk.main()
 
-Using OpenGL from PyGObject via new render context API 
+Using OpenGL from PyGObject via new render context API
 ......................................................
 
 Just like it is possible to render into a GTK widget through X11 windows, it `also is possible to render into a GTK

--- a/mpv.py
+++ b/mpv.py
@@ -144,7 +144,7 @@ class MpvOpenGLFBO(Structure):
             ('w', c_int),
             ('h', c_int),
             ('internal_format', c_int)]
-    
+
     def __init__(self, w, h, fbo=0, internal_format=0):
         self.w, self.h = w, h
         self.fbo = fbo
@@ -164,7 +164,7 @@ class MpvOpenGLDRMParams(Structure):
         ('connector_id', c_int),
         ('atomic_request_ptr', c_void_p),
         ('render_fd', c_int)]
-        
+
 class MpvOpenGLDRMDrawSurfaceSize(Structure):
     _fields_ = [('width', c_int), ('height', c_int)]
 


### PR DESCRIPTION
The last tag added a few superflous whitespaces to the code. This PR removes them.