### PR TITLE
Make dll use full path on Windows

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -34,7 +34,7 @@ if os.name == 'nt':
                       'with your script and put the directory your script is in into %PATH% before "import mpv": '
                       'os.environ["PATH"] = os.path.dirname(__file__) + os.pathsep + os.environ["PATH"] '
                       'If mpv-1.dll is located elsewhere, you can add that path to os.environ["PATH"].')
-    backend = CDLL(dll)
+    backend = CDLL(os.path.abspath(dll))
     fs_enc = 'utf-8'
 else:
     import locale


### PR DESCRIPTION
This fixes `FileNotFoundError: Could not find module 'mpv-1.dll'. Try using the full path with constructor syntax.` exception and issue #104 when libmpv is located next to running script.