### PR TITLE
Updated mpv.py to support python 3.8

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -34,7 +34,9 @@ if os.name == 'nt':
                       'with your script and put the directory your script is in into %PATH% before "import mpv": '
                       'os.environ["PATH"] = os.path.dirname(__file__) + os.pathsep + os.environ["PATH"] '
                       'If mpv-1.dll is located elsewhere, you can add that path to os.environ["PATH"].')
-    backend = CDLL(dll)
+    # Starting with version 3.8, CPython does not consider the PATH environment
+    # variable any more when resolving DLL paths.
+    backend = CDLL(os.path.abspath(dll))
     fs_enc = 'utf-8'
 else:
     import locale


### PR DESCRIPTION
From the Python 3.8 release notes:
> DLL dependencies for extension modules and DLLs loaded with ctypes on Windows are now resolved more securely. Only the system paths, the directory containing the DLL or PYD file, and directories added with add_dll_directory() are searched for load-time dependencies. Specifically, PATH and the current working directory are no longer used, and modifications to these will no longer have any effect on normal DLL resolution. If your application relies on these mechanisms, you should check for add_dll_directory() and if it exists, use it to add your DLLs directory while loading your library. Note that Windows 7 users will need to ensure that Windows Update KB2533623 has been installed (this is also verified by the installer).

This marks my first time contributing to an open-source project in GitHub! 🥳