### PR TITLE
added "python_requires"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     test_suite = 'mpv-test',
     keywords = ['mpv', 'library', 'video', 'audio', 'player', 'display',
         'multimedia'],
+    python_requires='>=3.5',
     classifiers = [
         'Development Status :: 4 - Beta',
         'Environment :: X11 Applications',


### PR DESCRIPTION
people are installing this package in python2 and running into issues of syntax error which is only used in pyhon3.5, thus the need of `python_requires`