### PR TITLE
Fix handling of c_void_p args in MpvRenderParam.__init__()

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -225,6 +225,9 @@ class MpvRenderParam(Structure):
         elif cons is bool:
             self.value = c_int(int(bool(value)))
             self.data = cast(pointer(self.value), c_void_p)
+        elif cons is c_void_p:
+            self.value = value
+            self.data = cast(self.value, c_void_p)
         else:
             self.value = cons(**value)
             self.data = cast(pointer(self.value), c_void_p)


### PR DESCRIPTION
Handling of c_void_p args (x11_display, wl_display) was broken.
Added a case to correctly handle the c_void_p constructor case.

See #169