### PR TITLE
test_property_observer_decorator: bump sleep to 0.1s

### DIFF
--- a/tests/test_mpv.py
+++ b/tests/test_mpv.py
@@ -291,7 +291,7 @@ class ObservePropertyTest(MpvTestCase):
         self.assertEqual(m.mute, True)
         self.assertEqual(m.slang, ['ru'])
 
-        time.sleep(0.05)
+        time.sleep(0.1)
         foo.unobserve_mpv_properties()
 
         m.mute = False


### PR DESCRIPTION
Fixes flaky test with mpv 0.33.1 on ppc64el.
Closes #178.
