### PR TITLE
mpv.py: change mpv_detach_destroy to mpv_destroy

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -531,7 +531,7 @@ _mpv_create = backend.mpv_create
 _handle_func('mpv_create_client',           [c_char_p],                                 MpvHandle, notnull_errcheck)
 _handle_func('mpv_client_name',             [],                                         c_char_p, errcheck=None)
 _handle_func('mpv_initialize',              [],                                         c_int, ec_errcheck)
-_handle_func('mpv_detach_destroy',          [],                                         None, errcheck=None)
+_handle_func('mpv_destroy',          [],                                         None, errcheck=None)
 _handle_func('mpv_terminate_destroy',       [],                                         None, errcheck=None)
 _handle_func('mpv_load_config_file',        [c_char_p],                                 c_int, ec_errcheck)
 _handle_func('mpv_get_time_us',             [],                                         c_ulonglong, errcheck=None)
@@ -884,7 +884,7 @@ class MPV(object):
                         self._message_handlers[target](*args)
 
                 if eid == MpvEventID.SHUTDOWN:
-                    _mpv_detach_destroy(self._event_handle)
+                    _mpv_destroy(self._event_handle)
                     return
 
             except Exception as e:


### PR DESCRIPTION
because mpv_detach_destroy is deprecated and will be deleted in mpv 0.35.0