### PR TITLE
Error for known-incompatible libmpv (closes #223)

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -537,6 +537,11 @@ def _mpv_client_api_version():
     ver = backend.mpv_client_api_version()
     return ver>>16, ver&0xFFFF
 
+MPV_VERSION = _mpv_client_api_version()
+if MPV_VERSION < (1, 108):
+    ver = '.'.join(str(num) for num in MPV_VERSION)
+    raise RuntimeError(f"python-mpv requires libmpv with an API version of 1.108 or higher (libmpv >= 0.33), but you have an older version ({ver}).")
+
 backend.mpv_free.argtypes = [c_void_p]
 _mpv_free = backend.mpv_free
 


### PR DESCRIPTION
This PR adds an explicit error if the user's `libmpv` is known to be incompatible with `python-mpv`. With these changes, an incompatibility is reported as:

```
$ python3 -c "import mpv"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/snoopjedi/repos/python-mpv/mpv.py", line 543, in <module>
    raise RuntimeError(f"python-mpv requires libmpv with an API version of 1.108 or higher (libmpv >= 0.33), but you have an older version ({ver}).")
RuntimeError: python-mpv requires libmpv with an API version of 1.108 or higher (libmpv >= 0.33), but you have an older version (1.107).
```

Instead of the more obscure error about missing symbols (see #223)