### PR TITLE
Add field "playlist_entry_id" to MpvEventEndFile

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -443,9 +443,12 @@ class MpvEventLogMessage(Structure):
         return lazy_decoder(self._text)
 
 class MpvEventEndFile(Structure):
-    _fields_ = [('reason', c_int),
-                ('error', c_int)]
-
+    _fields_ = [
+        ('reason', c_int),
+        ('error', c_int),
+        ('playlist_entry_id', c_ulonglong),
+    ]
+    
     EOF                 = 0
     RESTARTED           = 1
     ABORTED             = 2


### PR DESCRIPTION
I was trying to figure out exactly which item in my playlist was creating the MpvEventEndFile and I noticed in the [mpv.io docs](https://mpv.io/manual/stable/#command-interface-playlist-entry-id) that the MpvEventEndFile contains a `playlist_entry_id` field just like the MpvEventStartFile so I copied the field.  Let me know if there's anything else needed such as a unit test. :)