### PR TITLE
Windows: Fixed FileNotFoundError when copying dependencies to the project folder

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -38,7 +38,7 @@ if os.name == 'nt':
     dll = ctypes.util.find_library('mpv-2.dll') or ctypes.util.find_library('libmpv-2.dll') or ctypes.util.find_library('mpv-1.dll')
     if dll is None:
         raise OSError('Cannot find mpv-1.dll, mpv-2.dll or libmpv-2.dll in your system %PATH%. One way to deal with this is to ship the dll with your script and put the directory your script is in into %PATH% before "import mpv": os.environ["PATH"] = os.path.dirname(__file__) + os.pathsep + os.environ["PATH"] If mpv-1.dll is located elsewhere, you can add that path to os.environ["PATH"].')
-    backend = CDLL(dll)
+    backend = CDLL(dll, winmode=0)
     fs_enc = 'utf-8'
 else:
     import locale


### PR DESCRIPTION
If you copy the dll files to the project folder. It will throw a FileNotFoundError because of the default CDLL mode(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS).
It expects a full path to the file but for some reason ctypes.util.find_library only returns the file name if its in the project directory next to the mpv.py. Thats why the workaround(https://github.com/jaseg/python-mpv/issues/60#issuecomment-352719773) putting the dependencies in the script folder works since it returns the full path.
Adding winmode=0 fixes this issue and the user can now put the dependencies in the project directory or in the script folder.
For unit tests you would need to copy the dependencies in the tests folder as well.

It might be better to use a different approach to find the dll but this might be enough since it shouldn't break anything if it does let me know.

Closes #104