### PR TITLE
Fix race in event wait setup

### DIFF
--- a/mpv.py
+++ b/mpv.py
@@ -1118,6 +1118,7 @@ class MPV(object):
         handled in the interval between keypress(...) running and a subsequent wait_for_event(...) call.
         """
         result = Future()
+        result.set_running_or_notify_cancel()
 
         @self.event_callback(*event_types)
         def target_handler(evt):
@@ -1136,7 +1137,6 @@ class MPV(object):
         err_unregister = self._set_error_handler(result)
 
         try:
-            result.set_running_or_notify_cancel()
             if catch_errors:
                 self._exception_futures.add(result)
 

--- a/tests/test_mpv.py
+++ b/tests/test_mpv.py
@@ -23,6 +23,7 @@ from contextlib import contextmanager
 import os.path
 import os
 import time
+import types
 from concurrent.futures import Future, InvalidStateError
 
 os.environ["PATH"] = os.path.dirname(__file__) + os.pathsep + os.environ["PATH"]
@@ -690,6 +691,24 @@ class TestStreams(unittest.TestCase):
 
 
 class TestLifecycle(unittest.TestCase):
+    def test_wait_for_event_handles_immediate_event(self):
+        m = object.__new__(mpv.MPV)
+        m._exception_futures = set()
+        event = mock.Mock()
+
+        def event_callback(self, *event_types):
+            def register(callback):
+                callback.unregister_mpv_events = mock.Mock()
+                callback(event)
+                return callback
+            return register
+
+        m.event_callback = types.MethodType(event_callback, m)
+        m._set_error_handler = mock.Mock(return_value=mock.Mock())
+        m.check_core_alive = mock.Mock()
+
+        self.assertIs(m.wait_for_event('end_file', timeout=0), True)
+
     def test_create_destroy(self):
         thread_names = lambda: [ t.name for t in threading.enumerate() ]
         self.assertNotIn('MPVEventHandlerThread', thread_names())


### PR DESCRIPTION
Closes #61

## Summary
- Marks the wait Future as running before registering event callbacks in prepare_and_wait_for_event().
- Prevents an immediately delivered event from completing the future before set_running_or_notify_cancel() is called.
- Adds a regression test that simulates an event firing during registration without starting a real libmpv instance.

Fixes #61.

## Verification
- python -m py_compile mpv.py tests/test_mpv.py
- git diff --check

## Notes
- I could not run the focused unittest locally because this Windows environment does not have mpv-1.dll, mpv-2.dll, or libmpv-2.dll available for import mpv.